### PR TITLE
Add wireframe layout for Space Capsule Homes site

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Contact - Space Capsule Homes Moldova</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-content">
+      <div class="logo">Space Capsule Homes</div>
+      <nav class="site-nav">
+        <a href="index.html#hero">Hero</a>
+        <a href="index.html#quiz">Quiz</a>
+        <a href="index.html#scenarios">Scenarios</a>
+        <a href="index.html#models">Models</a>
+        <a href="index.html#configurator">Configurator</a>
+        <a href="index.html#services">Services</a>
+        <a href="index.html#showroom">Showroom</a>
+        <a href="index.html#gallery">Gallery</a>
+        <a href="index.html#faq">FAQ</a>
+        <a href="#contact">Contact</a>
+      </nav>
+      <a class="button" href="index.html#showroom-form">Book Showroom Visit</a>
+    </div>
+  </header>
+
+  <main>
+    <section id="contact" class="section">
+      <div class="container">
+        <h1>Contact Space Capsule Homes</h1>
+        <p class="subheading">Wireframe-only contact page placeholder.</p>
+        <div class="contact-layout">
+          <div class="contact-card">
+            <h2>Details</h2>
+            <ul>
+              <li>Phone: +373 placeholder</li>
+              <li>Email: contact placeholder</li>
+              <li>Showroom: Sîngera, Moldova</li>
+              <li>Hours: placeholder</li>
+            </ul>
+          </div>
+          <div class="contact-form">
+            <h2>Send a Message</h2>
+            <form>
+              <div class="form-row"><label>Name</label><input type="text" placeholder="Name"></div>
+              <div class="form-row"><label>Phone*</label><input type="text" placeholder="Phone"></div>
+              <div class="form-row"><label>Email</label><input type="email" placeholder="Email"></div>
+              <div class="form-row"><label>Purpose</label><select><option>Primary</option><option>Vacation</option><option>Investment</option></select></div>
+              <div class="form-row"><label>Message</label><textarea placeholder="Message"></textarea></div>
+              <div class="form-row consent"><input type="checkbox" id="contact-page-consent"><label for="contact-page-consent">Consent</label></div>
+              <div class="form-row"><button type="submit" class="button">Submit</button></div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-grid">
+      <div class="footer-column">
+        <div class="logo">Space Capsule Homes</div>
+        <p>Turn-key modular homes in Moldova.</p>
+      </div>
+      <div class="footer-column">
+        <h3>Contact</h3>
+        <p>Phone: +373 placeholder</p>
+        <p>Email: contact placeholder</p>
+        <p>Address: Sîngera</p>
+      </div>
+      <div class="footer-column">
+        <h3>Email Capture</h3>
+        <form>
+          <input type="email" placeholder="Email">
+          <button type="submit" class="button">Submit</button>
+        </form>
+      </div>
+      <div class="footer-column">
+        <h3>Legal</h3>
+        <ul>
+          <li>Privacy placeholder</li>
+          <li>Terms placeholder</li>
+        </ul>
+      </div>
+    </div>
+    <p class="footer-note">© Space Capsule Homes Moldova</p>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,522 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Space Capsule Homes Moldova - Wireframe</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-content">
+      <div class="logo">Space Capsule Homes</div>
+      <nav class="site-nav">
+        <a href="#hero">Hero</a>
+        <a href="#quiz">Quiz</a>
+        <a href="#scenarios">Scenarios</a>
+        <a href="#models">Models</a>
+        <a href="#configurator">Configurator</a>
+        <a href="#services">Services</a>
+        <a href="#showroom">Showroom</a>
+        <a href="#gallery">Gallery</a>
+        <a href="#faq">FAQ</a>
+        <a href="#contact">Contact</a>
+      </nav>
+      <a class="button" href="#showroom-form">Book Showroom Visit</a>
+    </div>
+  </header>
+
+  <main>
+    <section id="hero" class="section">
+      <div class="container">
+        <h1>Space Capsule Homes in Moldova — Turn-Key Modular Homes</h1>
+        <p class="subheading">Commercial pricing from €75–100k (base). Import + installation included.</p>
+        <div class="badge-row">
+          <span class="badge">Transparent Import from China</span>
+          <span class="badge">Quality Control</span>
+          <span class="badge">Showroom in Sîngera (~10 min from airport)</span>
+        </div>
+        <div class="cta-row">
+          <a class="button" href="#configurator">Configure My Home</a>
+          <a class="button secondary" href="#showroom-form">Book Showroom Visit</a>
+        </div>
+        <div class="media-placeholder">
+          <div class="media-box">VSL Placeholder</div>
+          <div class="media-label">Thumbnail + Play Icon</div>
+        </div>
+      </div>
+    </section>
+
+    <section id="quiz" class="section">
+      <div class="container">
+        <h2>What’s your goal?</h2>
+        <div class="quiz-buttons">
+          <button type="button" class="wire-button">Primary Home</button>
+          <button type="button" class="wire-button">Vacation Home</button>
+          <button type="button" class="wire-button">Investment</button>
+        </div>
+        <div class="quiz-flow">
+          <div class="progress-bar">
+            <div class="progress-fill">Progress 40%</div>
+          </div>
+          <div class="questions-grid">
+            <div class="question-box">Budget Range?</div>
+            <div class="question-box">Have land? (Y/N)</div>
+            <div class="question-box">Timeline?</div>
+            <div class="question-box">Off-Grid? (Y/N)</div>
+            <div class="question-box">Parking Needed? (Y/N)</div>
+            <div class="question-box">Notes Placeholder</div>
+          </div>
+        </div>
+        <div class="quiz-result">
+          <div class="result-summary">Result summary placeholder with key insights.</div>
+          <button type="button" class="button">Get My Offer</button>
+          <div class="lead-form">
+            <div class="form-title">Lead Form Modal Placeholder</div>
+            <form>
+              <div class="form-row"><label>Name</label><input type="text" placeholder="Name"></div>
+              <div class="form-row"><label>Phone*</label><input type="text" placeholder="Phone"></div>
+              <div class="form-row"><label>Email</label><input type="email" placeholder="Email"></div>
+              <div class="form-row"><label>Purpose</label><select><option>Primary</option><option>Vacation</option><option>Investment</option></select></div>
+              <div class="form-row"><label>Budget</label><input type="text" placeholder="€"></div>
+              <div class="form-row"><label>Land</label><select><option>Yes</option><option>No</option></select></div>
+              <div class="form-row"><label>Timeline</label><input type="text" placeholder="Timeline"></div>
+              <div class="form-row"><label>Notes</label><textarea placeholder="Notes"></textarea></div>
+              <div class="form-row consent"><input type="checkbox" id="quiz-consent"><label for="quiz-consent">Consent</label></div>
+              <div class="form-row"><button type="submit" class="button">Submit</button></div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="scenarios" class="section">
+      <div class="container">
+        <h2>Scenario Comparison</h2>
+        <div class="tab-row">
+          <div class="tab">Primary Home</div>
+          <div class="tab">Vacation Home</div>
+          <div class="tab">Investment</div>
+        </div>
+        <div class="tab-content">
+          <div class="tab-card">
+            <h3>Primary Home</h3>
+            <ul>
+              <li>Compare to apartment purchase (~€150k)</li>
+              <li>Own land, fast setup, lower monthly costs</li>
+            </ul>
+          </div>
+          <div class="tab-card">
+            <h3>Vacation Home</h3>
+            <ul>
+              <li>Modern “dacha” concept</li>
+              <li>Warm shell, kitchen/bath, terrace</li>
+              <li>Connection timeline placeholder</li>
+            </ul>
+          </div>
+          <div class="tab-card">
+            <h3>Investment</h3>
+            <ul>
+              <li>Nightly rate range placeholder</li>
+              <li>Occupancy example placeholder</li>
+              <li>OPEX items, self check-in, smart locks</li>
+              <li>Management option placeholder</li>
+            </ul>
+          </div>
+        </div>
+        <div class="metrics-row">
+          <div class="metric-box">Est. Monthly Costs</div>
+          <div class="metric-box">Setup Time</div>
+          <div class="metric-box">Flexibility</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="market">
+      <div class="container two-column">
+        <div class="column">
+          <h2>Local market gap</h2>
+          <p>Container-level builds with poor insulation or fully custom builds at traditional house pricing.</p>
+        </div>
+        <div class="column">
+          <h2>We fill the middle</h2>
+          <p>Factory-built quality, modern look, clear budget & timeline.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="transparency" class="section">
+      <div class="container">
+        <h2>Transparency: Import & QA</h2>
+        <ul class="checklist">
+          <li>Factory selection</li>
+          <li>Pre-shipment inspection</li>
+          <li>Shipping & insurance</li>
+          <li>Customs handling</li>
+          <li>Local installation</li>
+          <li>Warranty / Service</li>
+        </ul>
+        <div class="map-note">
+          <div class="map-placeholder">World Map Placeholder</div>
+          <p>Where similar homes exist (illustrative)</p>
+        </div>
+        <p class="note">Compact homes trend; public figure case (Musk) mentioned—no brand promises.</p>
+      </div>
+    </section>
+
+    <section id="models" class="section">
+      <div class="container">
+        <h2>Models & “From” Pricing</h2>
+        <div class="card-grid three">
+          <div class="card">
+            <h3>S (Studio) — from €75k</h3>
+            <div class="dimensions-box">Dimensions Placeholder</div>
+            <div class="plan-box">Plan Placeholder</div>
+            <ul>
+              <li>Includes: insulated shell</li>
+              <li>Kitchen</li>
+              <li>Bathroom</li>
+              <li>Interior finish</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>M (1 Bedroom) — from €85k</h3>
+            <div class="dimensions-box">Dimensions Placeholder</div>
+            <div class="plan-box">Plan Placeholder</div>
+            <ul>
+              <li>Includes: insulated shell</li>
+              <li>Kitchen</li>
+              <li>Bathroom</li>
+              <li>Interior finish</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>L (2 Bedrooms) — from €100k</h3>
+            <div class="dimensions-box">Dimensions Placeholder</div>
+            <div class="plan-box">Plan Placeholder</div>
+            <ul>
+              <li>Includes: insulated shell</li>
+              <li>Kitchen</li>
+              <li>Bathroom</li>
+              <li>Interior finish</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="configurator" class="section">
+      <div class="container configurator">
+        <h2>Configurator Structure</h2>
+        <div class="config-grid">
+          <div class="config-options">
+            <div class="option-group">
+              <h3>Size</h3>
+              <label><input type="radio" name="size"> S</label>
+              <label><input type="radio" name="size"> M</label>
+              <label><input type="radio" name="size"> L</label>
+            </div>
+            <div class="option-group">
+              <h3>Finish</h3>
+              <label><input type="radio" name="finish"> Light</label>
+              <label><input type="radio" name="finish"> Natural</label>
+              <label><input type="radio" name="finish"> Dark</label>
+            </div>
+            <div class="option-group">
+              <h3>Kitchen</h3>
+              <label><input type="radio" name="kitchen"> Basic</label>
+              <label><input type="radio" name="kitchen"> Plus</label>
+            </div>
+            <div class="option-group">
+              <h3>Bathroom</h3>
+              <label><input type="radio" name="bathroom"> Basic</label>
+              <label><input type="radio" name="bathroom"> Plus</label>
+            </div>
+            <div class="option-group">
+              <h3>Energy</h3>
+              <label><input type="radio" name="energy"> None</label>
+              <label><input type="radio" name="energy"> Grid-Ready</label>
+              <label><input type="radio" name="energy"> Off-Grid</label>
+            </div>
+            <div class="option-group">
+              <h3>Climate</h3>
+              <label><input type="radio" name="climate"> None</label>
+              <label><input type="radio" name="climate"> Comfort</label>
+              <label><input type="radio" name="climate"> Winter+</label>
+            </div>
+            <div class="option-group">
+              <h3>Smart</h3>
+              <label><input type="radio" name="smart"> None</label>
+              <label><input type="radio" name="smart"> Entry</label>
+              <label><input type="radio" name="smart"> Full</label>
+            </div>
+            <div class="option-group">
+              <h3>Outdoor</h3>
+              <label><input type="radio" name="outdoor"> None</label>
+              <label><input type="radio" name="outdoor"> Terrace</label>
+              <label><input type="radio" name="outdoor"> Terrace + Carport</label>
+            </div>
+            <div class="option-group">
+              <h3>Extras</h3>
+              <label><input type="checkbox"> Floor heating</label>
+              <label><input type="checkbox"> Panoramic windows</label>
+              <label><input type="checkbox"> Built-ins</label>
+            </div>
+          </div>
+          <div class="config-summary">
+            <div class="summary-box">
+              <h3>Estimated Price</h3>
+              <p>Placeholder value</p>
+            </div>
+            <div class="summary-box">
+              <h3>Estimated Lead Time</h3>
+              <p>Placeholder range</p>
+            </div>
+            <div class="summary-box">
+              <p>Weight / transport note placeholder</p>
+            </div>
+            <div class="config-cta">
+              <button type="button" class="button">Save Configuration (email)</button>
+              <button type="button" class="button">Request Detailed Quote</button>
+              <button type="button" class="button secondary">Share Link</button>
+            </div>
+            <p class="disclaimer">Estimates only. Final pricing after spec & logistics confirmation.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="services" class="section">
+      <div class="container">
+        <h2>Service Packages</h2>
+        <div class="card-grid four">
+          <div class="card">Import Only<br>Fixed fee placeholder</div>
+          <div class="card">Consulting<br>Packages / hourly placeholder</div>
+          <div class="card">Guided Build<br>Fixed + % of procurement</div>
+          <div class="card">Turn-Key<br>Project management (~10% fee)</div>
+        </div>
+        <div class="investor-row">Investor add-on: Property Management (rev share placeholder)</div>
+      </div>
+    </section>
+
+    <section id="showroom" class="section">
+      <div class="container">
+        <h2>Showroom (Sîngera)</h2>
+        <div class="showroom-grid">
+          <div class="map-placeholder">Map Placeholder</div>
+          <div class="showroom-info">
+            <div class="slots">
+              <h3>Visiting Slots</h3>
+              <ul>
+                <li>Slot placeholder (Date/Time)</li>
+                <li>Slot placeholder (Date/Time)</li>
+                <li>Slot placeholder (Date/Time)</li>
+              </ul>
+            </div>
+            <div id="showroom-form" class="showroom-form">
+              <h3>Book Showroom Visit</h3>
+              <form>
+                <div class="form-row"><label>Name</label><input type="text" placeholder="Name"></div>
+                <div class="form-row"><label>Phone*</label><input type="text" placeholder="Phone"></div>
+                <div class="form-row"><label>Email</label><input type="email" placeholder="Email"></div>
+                <div class="form-row"><label>Purpose</label><select><option>Primary</option><option>Vacation</option><option>Investment</option></select></div>
+                <div class="form-row"><label>Preferred Slot</label><input type="text" placeholder="Slot"></div>
+                <div class="form-row consent"><input type="checkbox" id="showroom-consent"><label for="showroom-consent">Consent</label></div>
+                <div class="form-row"><button type="submit" class="button">Book</button></div>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="gallery" class="section">
+      <div class="container">
+        <h2>Gallery & Real Examples</h2>
+        <div class="gallery-grid">
+          <div class="gallery-item">Factory</div>
+          <div class="gallery-item">Packaging</div>
+          <div class="gallery-item">Delivery</div>
+          <div class="gallery-item">Mounting</div>
+          <div class="gallery-item">Before / After</div>
+          <div class="gallery-item">Night Shots</div>
+          <div class="gallery-item">Floor Plans</div>
+          <div class="gallery-item">Video Placeholder</div>
+          <div class="gallery-item">Video Placeholder</div>
+        </div>
+      </div>
+    </section>
+
+    <section id="faq" class="section">
+      <div class="container">
+        <h2>FAQ (Legal & Ops)</h2>
+        <div class="faq-list">
+          <details>
+            <summary>Permits: temporary vs permanent</summary>
+            <p>Short answer placeholder.</p>
+          </details>
+          <details>
+            <summary>Utilities: water</summary>
+            <p>Short answer placeholder.</p>
+          </details>
+          <details>
+            <summary>Utilities: septic</summary>
+            <p>Short answer placeholder.</p>
+          </details>
+          <details>
+            <summary>Utilities: electric</summary>
+            <p>Short answer placeholder.</p>
+          </details>
+          <details>
+            <summary>Utilities: internet</summary>
+            <p>Short answer placeholder.</p>
+          </details>
+          <details>
+            <summary>Snow load</summary>
+            <p>Short answer placeholder.</p>
+          </details>
+          <details>
+            <summary>Wind and noise</summary>
+            <p>Short answer placeholder.</p>
+          </details>
+          <details>
+            <summary>Warranty & service</summary>
+            <p>Short answer placeholder.</p>
+          </details>
+          <details>
+            <summary>Timelines</summary>
+            <p>Production, shipping, customs, install placeholders.</p>
+          </details>
+          <details>
+            <summary>Payment, deposit, refund</summary>
+            <p>Short answer placeholder.</p>
+          </details>
+          <details>
+            <summary>Relocation & resale</summary>
+            <p>Short answer placeholder.</p>
+          </details>
+        </div>
+      </div>
+    </section>
+
+    <section id="final-cta" class="section">
+      <div class="container final-cta">
+        <div class="cta-block">
+          <h3>Save My Configuration</h3>
+          <button type="button" class="button">Save</button>
+        </div>
+        <div class="cta-block">
+          <h3>Book Showroom Visit</h3>
+          <button type="button" class="button">Book</button>
+        </div>
+        <p class="note">Early-bird batch (Spring): N slots, deposit X% to lock price & queue.</p>
+      </div>
+    </section>
+
+    <section id="contact" class="section">
+      <div class="container">
+        <h2>Contact Snapshot</h2>
+        <div class="contact-summary">
+          <div>Phone: +373 placeholder</div>
+          <div>Email: info placeholder</div>
+          <div>Address: Sîngera, Moldova</div>
+        </div>
+        <div class="contact-form">
+          <form>
+            <div class="form-row"><label>Name</label><input type="text" placeholder="Name"></div>
+            <div class="form-row"><label>Phone*</label><input type="text" placeholder="Phone"></div>
+            <div class="form-row"><label>Email</label><input type="email" placeholder="Email"></div>
+            <div class="form-row"><label>Purpose</label><select><option>Primary</option><option>Vacation</option><option>Investment</option></select></div>
+            <div class="form-row"><label>Budget</label><input type="text" placeholder="Budget"></div>
+            <div class="form-row"><label>Land</label><select><option>Yes</option><option>No</option></select></div>
+            <div class="form-row"><label>Timeline</label><input type="text" placeholder="Timeline"></div>
+            <div class="form-row"><label>Message</label><textarea placeholder="Message"></textarea></div>
+            <div class="form-row consent"><input type="checkbox" id="contact-consent"><label for="contact-consent">Consent</label></div>
+            <div class="form-row"><button type="submit" class="button">Send</button></div>
+          </form>
+        </div>
+      </div>
+    </section>
+
+    <section id="cms" class="section">
+      <div class="container">
+        <h2>CMS / Data Structures</h2>
+        <div class="cms-grid">
+          <div class="cms-card">
+            <h3>Models</h3>
+            <ul>
+              <li>name</li>
+              <li>base_price_from</li>
+              <li>dimensions</li>
+              <li>includes[]</li>
+              <li>plan_placeholder</li>
+            </ul>
+          </div>
+          <div class="cms-card">
+            <h3>Packs</h3>
+            <ul>
+              <li>Energy options</li>
+              <li>Climate options</li>
+              <li>Smart options</li>
+              <li>Outdoor options</li>
+              <li>Design options</li>
+              <li>delta_price placeholder</li>
+            </ul>
+          </div>
+          <div class="cms-card">
+            <h3>FAQ</h3>
+            <ul>
+              <li>question</li>
+              <li>short_answer</li>
+            </ul>
+          </div>
+          <div class="cms-card">
+            <h3>Gallery Items</h3>
+            <ul>
+              <li>type</li>
+              <li>caption</li>
+            </ul>
+          </div>
+          <div class="cms-card">
+            <h3>Showroom Slots</h3>
+            <ul>
+              <li>date/time</li>
+              <li>capacity</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-grid">
+      <div class="footer-column">
+        <div class="logo">Space Capsule Homes</div>
+        <p>Turn-key modular homes in Moldova.</p>
+      </div>
+      <div class="footer-column">
+        <h3>Contact</h3>
+        <p>Phone: +373 placeholder</p>
+        <p>Email: contact placeholder</p>
+        <p>Address: Sîngera</p>
+      </div>
+      <div class="footer-column">
+        <h3>Email Capture</h3>
+        <form>
+          <input type="email" placeholder="Email">
+          <button type="submit" class="button">Submit</button>
+        </form>
+      </div>
+      <div class="footer-column">
+        <h3>Legal</h3>
+        <ul>
+          <li>Privacy placeholder</li>
+          <li>Terms placeholder</li>
+        </ul>
+      </div>
+    </div>
+    <p class="footer-note">© Space Capsule Homes Moldova</p>
+  </footer>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,528 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background: #f5f5f5;
+  color: #333;
+}
+
+.container {
+  width: 90%;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.section {
+  padding: 48px 0;
+  border-bottom: 1px solid #d0d0d0;
+}
+
+.site-header,
+.site-footer {
+  background: #fff;
+  border-bottom: 1px solid #ccc;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.header-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 0;
+}
+
+.logo {
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.site-nav {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 14px;
+}
+
+.site-nav a {
+  text-decoration: none;
+  color: #333;
+  padding: 4px 8px;
+  border: 1px solid #ccc;
+  border-radius: 2px;
+}
+
+.button {
+  display: inline-block;
+  padding: 8px 16px;
+  border: 2px solid #333;
+  background: #e0e0e0;
+  color: #111;
+  text-decoration: none;
+  text-align: center;
+  font-weight: bold;
+  border-radius: 4px;
+}
+
+.button.secondary {
+  background: #fff;
+}
+
+h1, h2, h3 {
+  margin-top: 0;
+  color: #111;
+}
+
+.subheading {
+  margin-bottom: 24px;
+  max-width: 640px;
+}
+
+.badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 24px;
+}
+
+.badge {
+  padding: 6px 12px;
+  border: 1px dashed #666;
+  background: #eaeaea;
+  font-size: 14px;
+}
+
+.cta-row {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+}
+
+.media-placeholder {
+  display: grid;
+  gap: 8px;
+  max-width: 400px;
+  border: 1px solid #bbb;
+  padding: 16px;
+  background: #ddd;
+}
+
+.media-box {
+  height: 180px;
+  border: 2px dashed #999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+}
+
+.media-label {
+  text-align: center;
+  font-size: 14px;
+}
+
+.quiz-buttons {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+}
+
+.wire-button {
+  padding: 16px 24px;
+  border: 2px solid #333;
+  background: #f0f0f0;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.quiz-flow {
+  margin-bottom: 24px;
+}
+
+.progress-bar {
+  border: 1px solid #999;
+  height: 28px;
+  margin-bottom: 16px;
+  background: #f0f0f0;
+  display: flex;
+  align-items: center;
+}
+
+.progress-fill {
+  width: 40%;
+  height: 100%;
+  background: #ccc;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+}
+
+.questions-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.question-box {
+  border: 1px solid #aaa;
+  background: #e7e7e7;
+  padding: 16px;
+  text-align: center;
+  min-height: 80px;
+}
+
+.quiz-result {
+  border: 1px solid #bbb;
+  padding: 24px;
+  background: #f9f9f9;
+  display: grid;
+  gap: 16px;
+}
+
+.result-summary {
+  border: 1px dashed #999;
+  padding: 16px;
+  background: #fff;
+}
+
+.lead-form {
+  border: 1px dashed #ccc;
+  padding: 16px;
+  background: #fff;
+}
+
+.form-title {
+  font-weight: bold;
+  margin-bottom: 12px;
+}
+
+.form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
+}
+
+.form-row input,
+.form-row select,
+.form-row textarea {
+  padding: 8px;
+  border: 1px solid #888;
+  background: #f7f7f7;
+}
+
+.form-row textarea {
+  min-height: 80px;
+}
+
+.form-row.consent {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+
+.tab-row {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.tab {
+  padding: 12px 16px;
+  border: 2px dashed #555;
+  background: #eee;
+}
+
+.tab-content {
+  display: grid;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.tab-card {
+  border: 1px solid #aaa;
+  background: #fff;
+  padding: 16px;
+}
+
+.metrics-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.metric-box {
+  border: 1px dashed #777;
+  padding: 16px;
+  text-align: center;
+  background: #eee;
+}
+
+.two-column {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 24px;
+}
+
+.checklist {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 24px;
+  display: grid;
+  gap: 8px;
+}
+
+.checklist li {
+  border: 1px dashed #666;
+  padding: 12px;
+  background: #fff;
+}
+
+.map-note {
+  display: grid;
+  gap: 12px;
+  max-width: 400px;
+}
+
+.map-placeholder {
+  height: 200px;
+  border: 2px dashed #aaa;
+  background: #eee;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+}
+
+.note {
+  font-size: 14px;
+  color: #444;
+}
+
+.card-grid.three {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.card-grid.four {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.card {
+  border: 1px solid #aaa;
+  background: #fff;
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+}
+
+.dimensions-box,
+.plan-box {
+  border: 1px dashed #999;
+  height: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #eee;
+}
+
+.configurator {
+  display: grid;
+  gap: 24px;
+}
+
+.config-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: 24px;
+}
+
+@media (max-width: 900px) {
+  .config-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.config-options {
+  border: 1px solid #bbb;
+  background: #fff;
+  padding: 16px;
+  display: grid;
+  gap: 16px;
+}
+
+.option-group {
+  border: 1px dashed #aaa;
+  padding: 12px;
+  display: grid;
+  gap: 8px;
+}
+
+.config-summary {
+  border: 1px solid #bbb;
+  background: #fdfdfd;
+  padding: 16px;
+  display: grid;
+  gap: 16px;
+  position: sticky;
+  top: 96px;
+  height: fit-content;
+}
+
+.summary-box {
+  border: 1px dashed #999;
+  padding: 12px;
+  background: #fff;
+}
+
+.config-cta {
+  display: grid;
+  gap: 8px;
+}
+
+.investor-row {
+  margin-top: 16px;
+  padding: 12px;
+  border: 1px dashed #888;
+  background: #f0f0f0;
+}
+
+.showroom-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
+}
+
+.map-placeholder {
+  min-height: 240px;
+}
+
+.showroom-form {
+  border: 1px solid #bbb;
+  padding: 16px;
+  background: #fff;
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+}
+
+.gallery-item {
+  border: 2px dashed #aaa;
+  background: #e5e5e5;
+  height: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  font-size: 14px;
+}
+
+.faq-list details {
+  border: 1px solid #bbb;
+  background: #fff;
+  padding: 12px;
+  margin-bottom: 8px;
+}
+
+.faq-list summary {
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.final-cta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+  align-items: start;
+}
+
+.cta-block {
+  border: 1px solid #999;
+  background: #fff;
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+  text-align: center;
+}
+
+.contact-summary {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.contact-form {
+  border: 1px solid #bbb;
+  background: #fff;
+  padding: 16px;
+}
+
+.cms-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+}
+
+.cms-card {
+  border: 1px dashed #999;
+  background: #fff;
+  padding: 16px;
+}
+
+.site-footer {
+  border-top: 1px solid #ccc;
+  padding: 32px 0;
+  margin-top: 48px;
+}
+
+.footer-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+  align-items: start;
+}
+
+.footer-column ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.footer-note {
+  text-align: center;
+  margin-top: 24px;
+  font-size: 14px;
+}
+
+.contact-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+  margin-top: 24px;
+}
+
+.contact-card {
+  border: 1px dashed #aaa;
+  background: #fff;
+  padding: 16px;
+}


### PR DESCRIPTION
## Summary
- build a single-page Home wireframe covering hero, quiz, scenarios, models, configurator, services, showroom, gallery, faq, and cms placeholders
- add a minimal Contact page sharing the same structure and form fields
- create grayscale wireframe styling for layout, grids, and placeholders

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf0f58d4b8832483eea2d2dbcd85ad